### PR TITLE
Scripts: Rename files with wrong extensions

### DIFF
--- a/scripts/Batch Rename/README.md
+++ b/scripts/Batch Rename/README.md
@@ -1,5 +1,9 @@
 # Batch Rename Scripts
 
+## Requirements
+
+The scripts require the `file` utility to be installed.
+
 ## Fix Extension of JPEG Files Matching the `*.HEIC` Pattern
 
 The [heic2jpg.sh](heic2jpg.sh) script changes the file extension of all JPEG images that incorrectly match the `*.HEIC` file name pattern from `.HEIC` to `.JPG`:
@@ -8,7 +12,7 @@ The [heic2jpg.sh](heic2jpg.sh) script changes the file extension of all JPEG ima
 ./heic2jpg.sh
 ```
 
-The script will scans the current directory and all subdirectories.
+The script will scan the current directory and all subdirectories.
 
 ## Fix Extension of HEIC Files Matching the `*.JPG` and `*.JPEG` Pattern
 
@@ -32,12 +36,14 @@ The script will scan the current directory and all subdirectories.
 
 ## Fix All Incorrect Extensions at Once
 
-The [fix-them-all.sh](fix-them-all.sh) script combines the functionality of all three scripts above into one convenient tool. It automatically detects the actual file type (HEIC, JPG, or PNG) and renames files to use the correct extension based on their MIME type:
+The [fix-them-all.sh](fix-them-all.sh) script combines the functionality of all three scripts above into one convenient tool. It automatically detects the actual file type (HEIC, JPG, PNG, or JP2) and renames files to use the correct extension based on their MIME type:
 
 ```bash
 ./fix-them-all.sh
 ```
 
-This script will scan the current directory and all subdirectories for files with `.HEIC`, `.JPG`, `.JPEG`, and `.PNG` extensions.
+This script will scan the current directory and all subdirectories for files with `.HEIC`, `.JPG`, `.JPEG`, and `.PNG` extensions. It also corrects JPEG 2000 files with the `.JP2` extension.
+
+**Note:** PhotoPrism currently does not support JPEG 2000 (JP2) files. It is recommended to test with a small sample before running a bulk process.
 
 *Contributed by [Miłosz Kosobucki](https://github.com/MiKom) and [Xie Yanbo](https://github.com/xyb).*

--- a/scripts/Batch Rename/README.md
+++ b/scripts/Batch Rename/README.md
@@ -10,4 +10,34 @@ The [heic2jpg.sh](heic2jpg.sh) script changes the file extension of all JPEG ima
 
 The script will scans the current directory and all subdirectories.
 
+## Fix Extension of HEIC Files Matching the `*.JPG` and `*.JPEG` Pattern
+
+The [jpg2heic.sh](jpg2heic.sh) script changes the file extension of all HEIC images that incorrectly match the `*.JPG` or `*.JPEG` file name pattern to `.HEIC`:
+
+```bash
+./jpg2heic.sh
+```
+
+The script will scan the current directory and all subdirectories.
+
+## Fix Extension of JPEG Files Matching the `*.PNG` Pattern
+
+The [png2jpg.sh](png2jpg.sh) script changes the file extension of all JPEG images that incorrectly match the `*.PNG` file name pattern from `.PNG` to `.JPG`:
+
+```bash
+./png2jpg.sh
+```
+
+The script will scan the current directory and all subdirectories.
+
+## Fix All Incorrect Extensions at Once
+
+The [fix-them-all.sh](fix-them-all.sh) script combines the functionality of all three scripts above into one convenient tool. It automatically detects the actual file type (HEIC, JPG, or PNG) and renames files to use the correct extension based on their MIME type:
+
+```bash
+./fix-them-all.sh
+```
+
+This script will scan the current directory and all subdirectories for files with `.HEIC`, `.JPG`, `.JPEG`, and `.PNG` extensions.
+
 *Contributed by [Miłosz Kosobucki](https://github.com/MiKom) and [Xie Yanbo](https://github.com/xyb).*

--- a/scripts/Batch Rename/fix-them-all.sh
+++ b/scripts/Batch Rename/fix-them-all.sh
@@ -3,7 +3,7 @@
 set -euo pipefail
 
 # This script changes the file extension of all HEIC, JPEG, JPG and PNG images
-# that using incorrectly file extension to it's actual name.
+# that are using incorrect file extensions to their actual names.
 # It scans the current directory and all subdirectories.
 
 find . -type d -name "@eaDir" -prune -o -type f \( -iname "*.JPEG" -o -iname "*.JPG" -o -iname "*.HEIC" -o -iname "*.PNG" \) -print0 | while IFS= read -r -d '' file; do

--- a/scripts/Batch Rename/fix-them-all.sh
+++ b/scripts/Batch Rename/fix-them-all.sh
@@ -4,7 +4,7 @@
 # that using incorrectly file extension to it's actual name.
 # It scans the current directory and all subdirectories.
 
-find . -type f \( -iname "*.JPEG" -o -iname "*.JPG" -o -iname "*.HEIC" -o -iname "*.PNG" \) -print0 | while IFS= read -r -d '' file; do
+find . -type d -name "@eaDir" -prune -o -type f \( -iname "*.JPEG" -o -iname "*.JPG" -o -iname "*.HEIC" -o -iname "*.PNG" \) -print0 | while IFS= read -r -d '' file; do
   mime_type=$(file --brief --mime-type -- "$file")
   filename=$(basename -- "$file")
   ext=".${filename##*.}"
@@ -20,6 +20,9 @@ find . -type f \( -iname "*.JPEG" -o -iname "*.JPG" -o -iname "*.HEIC" -o -iname
       else
         actual_ext=".JPG"
       fi
+      ;;
+    'image/jp2')
+      actual_ext=".JP2"
       ;;
     'image/png')
       actual_ext=".PNG"

--- a/scripts/Batch Rename/fix-them-all.sh
+++ b/scripts/Batch Rename/fix-them-all.sh
@@ -1,0 +1,34 @@
+#!/bin/bash
+
+# This script changes the file extension of all HEIC, JPEG, JPG and PNG images
+# that using incorrectly file extension to it's actual name.
+# It scans the current directory and all subdirectories.
+
+find . -type f \( -iname "*.JPEG" -o -iname "*.JPG" -o -iname "*.HEIC" -o -iname "*.PNG" \) -print0 | while IFS= read -r -d '' file; do
+  mime_type=$(file --brief --mime-type -- "$file")
+  filename=$(basename -- "$file")
+  ext=".${filename##*.}"
+  actual_ext=
+
+  case "$mime_type" in
+    'image/heic')
+      actual_ext=".HEIC"
+      ;;
+    'image/jpeg')
+      if [[ "${ext^^}" == ".JPG" || "${ext^^}" == ".JPEG" ]]; then
+        actual_ext="$ext"
+      else
+        actual_ext=".JPG"
+      fi
+      ;;
+    'image/png')
+      actual_ext=".PNG"
+      ;;
+  esac
+
+  if [[ -n "$actual_ext" && "${actual_ext^^}" != "${ext^^}" ]]; then
+    actual_name="${file%.*}${actual_ext}"
+    echo "Renaming \"$file\" to \"$actual_name\" ..."
+    mv -- "$file" "$actual_name"
+  fi
+done

--- a/scripts/Batch Rename/fix-them-all.sh
+++ b/scripts/Batch Rename/fix-them-all.sh
@@ -1,5 +1,7 @@
 #!/bin/bash
 
+set -euo pipefail
+
 # This script changes the file extension of all HEIC, JPEG, JPG and PNG images
 # that using incorrectly file extension to it's actual name.
 # It scans the current directory and all subdirectories.
@@ -8,14 +10,15 @@ find . -type d -name "@eaDir" -prune -o -type f \( -iname "*.JPEG" -o -iname "*.
   mime_type=$(file --brief --mime-type -- "$file")
   filename=$(basename -- "$file")
   ext=".${filename##*.}"
-  actual_ext=
+  ext_upper=$(echo "$ext" | tr '[:lower:]' '[:upper:]')
+  actual_ext=""
 
   case "$mime_type" in
     'image/heic')
       actual_ext=".HEIC"
       ;;
     'image/jpeg')
-      if [[ "${ext^^}" == ".JPG" || "${ext^^}" == ".JPEG" ]]; then
+      if [[ "$ext_upper" == ".JPG" || "$ext_upper" == ".JPEG" ]]; then
         actual_ext="$ext"
       else
         actual_ext=".JPG"
@@ -29,9 +32,12 @@ find . -type d -name "@eaDir" -prune -o -type f \( -iname "*.JPEG" -o -iname "*.
       ;;
   esac
 
-  if [[ -n "$actual_ext" && "${actual_ext^^}" != "${ext^^}" ]]; then
-    actual_name="${file%.*}${actual_ext}"
-    echo "Renaming \"$file\" to \"$actual_name\" ..."
-    mv -- "$file" "$actual_name"
+  if [ -n "$actual_ext" ]; then
+    actual_ext_upper=$(echo "$actual_ext" | tr '[:lower:]' '[:upper:]')
+    if [[ "$actual_ext_upper" != "$ext_upper" ]]; then
+      actual_name="${file%.*}${actual_ext}"
+      echo "Renaming \"$file\" to \"$actual_name\" ..."
+      mv -n -- "$file" "$actual_name"
+    fi
   fi
 done

--- a/scripts/Batch Rename/heic2jpg.sh
+++ b/scripts/Batch Rename/heic2jpg.sh
@@ -1,12 +1,15 @@
 #!/bin/bash
 
+set -euo pipefail
+
 # This script changes the file extension of all JPEG images that incorrectly
 # match the "*.HEIC" file name pattern from ".HEIC" to ".JPG".
 # It scans the current directory and all subdirectories.
 
 find . -type f -iname "*.HEIC" -print0 | while IFS= read -r -d '' file; do
   if file --brief --mime-type -- "$file" | grep -q '^image/jpeg$'; then
-    echo "Renaming \"$file\"..."
-    mv -- "$file" "${file%.*}.JPG" ;
+    jpg_name="${file%.*}.JPG"
+    echo "Renaming \"$file\" to \"$jpg_name\"..."
+    mv -n -- "$file" "$jpg_name"
   fi
 done

--- a/scripts/Batch Rename/jpg2heic.sh
+++ b/scripts/Batch Rename/jpg2heic.sh
@@ -1,12 +1,15 @@
 #!/bin/bash
 
+set -euo pipefail
+
 # This script changes the file extension of all HEIC images that incorrectly
 # match the "*.JPEG" or "*.JPG" file name pattern to ".HEIC".
 # It scans the current directory and all subdirectories.
 
-find . -type f \( -iname "*.JPEG" -or -iname "*.JPG" \) -print0 | while IFS= read -r -d '' file; do
+find . -type d -name "@eaDir" -prune -o -type f \( -iname "*.JPEG" -or -iname "*.JPG" \) -print0 | while IFS= read -r -d '' file; do
   if file --brief --mime-type -- "$file" | grep -q '^image/heic$'; then
-    echo "Renaming \"$file\"..."
-    mv -- "$file" "${file%.*}.HEIC" ;
+    heic_name="${file%.*}.HEIC"
+    echo "Renaming \"$file\" to \"$heic_name\"..."
+    mv -n -- "$file" "$heic_name"
   fi
 done

--- a/scripts/Batch Rename/jpg2heic.sh
+++ b/scripts/Batch Rename/jpg2heic.sh
@@ -1,0 +1,12 @@
+#!/bin/bash
+
+# This script changes the file extension of all HEIC images that incorrectly
+# match the "*.JPEG" or "*.JPG" file name pattern to ".HEIC".
+# It scans the current directory and all subdirectories.
+
+find . -type f \( -iname "*.JPEG" -or -iname "*.JPG" \) -print0 | while IFS= read -r -d '' file; do
+  if file --brief --mime-type -- "$file" | grep -q '^image/heic$'; then
+    echo "Renaming \"$file\"..."
+    mv -- "$file" "${file%.*}.HEIC" ;
+  fi
+done

--- a/scripts/Batch Rename/png2jpg.sh
+++ b/scripts/Batch Rename/png2jpg.sh
@@ -1,12 +1,15 @@
 #!/bin/bash
 
+set -euo pipefail
+
 # This script changes the file extension of all JPEG images that incorrectly
 # match the "*.PNG" file name pattern from ".PNG" to ".JPG".
 # It scans the current directory and all subdirectories.
 
-find . -type f -iname "*.PNG" -print0 | while IFS= read -r -d '' file; do
+find . -type d -name "@eaDir" -prune -o -type f -iname "*.PNG" -print0 | while IFS= read -r -d '' file; do
   if file --brief --mime-type -- "$file" | grep -q '^image/jpeg$'; then
-    echo "Renaming \"$file\"..."
-    mv -- "$file" "${file%.*}.JPG" ;
+    jpg_name="${file%.*}.JPG"
+    echo "Renaming \"$file\" to \"$jpg_name\"..."
+    mv -n -- "$file" "$jpg_name"
   fi
 done

--- a/scripts/Batch Rename/png2jpg.sh
+++ b/scripts/Batch Rename/png2jpg.sh
@@ -1,0 +1,12 @@
+#!/bin/bash
+
+# This script changes the file extension of all JPEG images that incorrectly
+# match the "*.PNG" file name pattern from ".PNG" to ".JPG".
+# It scans the current directory and all subdirectories.
+
+find . -type f -iname "*.PNG" -print0 | while IFS= read -r -d '' file; do
+  if file --brief --mime-type -- "$file" | grep -q '^image/jpeg$'; then
+    echo "Renaming \"$file\"..."
+    mv -- "$file" "${file%.*}.JPG" ;
+  fi
+done


### PR DESCRIPTION
This PR extends the functionality of heic2jpg.sh by adding new scripts to handle common image file extension issues:

- `jpg2heic.sh` - corrects JPG/JPEG files that should be HEIC
- `png2jpg.sh` - corrects PNG files that should be JPG/JPEG
- `fix_img_extensions.sh` - combined script to handle all cases in one pass

I have encountered issues with Synology Moments backup photos having incorrect file extensions, which prevents PhotoPrism indexing. These scripts will help automatically correct such issues.